### PR TITLE
Fix Commits sequence

### DIFF
--- a/Squashy/GitCommands.cs
+++ b/Squashy/GitCommands.cs
@@ -5,7 +5,9 @@ public static class GitCommands
     public static void DisplayCommits(string directory, int numCommits)
     {
         using var repo = new Repository(directory);
-        foreach (Commit commit in repo.Commits.Take(numCommits))
+        var filter = new CommitFilter { SortBy = CommitSortStrategies.Topological | CommitSortStrategies.Reverse };
+
+        foreach (Commit commit in repo.Commits.QueryBy(filter).Take(numCommits))
         {
             Console.WriteLine($"commit {commit.Id} - {commit.Message[..^1]}");
         }


### PR DESCRIPTION
closes #2 
use `commits.QueryBy()` instead of `commits.Take()` to ensure commits are topologically sorted