### PR TITLE
Add support for Squash dry-run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,5 @@ clean:
 	rm -rf publish
 	rm -rf ./Squashy/bin
 	rm -rf ./Squashy/obj
+squash-dry-run:
+	./publish/Squashy -d ./test-repo squash a35c0aa 6eeab88 "this is the squashed commit" -x

--- a/Squashy/GitCommands.cs
+++ b/Squashy/GitCommands.cs
@@ -35,13 +35,13 @@ public class GitCommands
 
     private IEnumerable<Commit> getCommits()
     {
-        var filter = new CommitFilter { SortBy = CommitSortStrategies.Topological | CommitSortStrategies.Reverse };
+        var filter = new CommitFilter { SortBy = CommitSortStrategies.Topological };
         return repo.Commits.QueryBy(filter);
     }
 
     private IEnumerable<Commit> getCommits(int numCommits)
     {
-        var filter = new CommitFilter { SortBy = CommitSortStrategies.Topological | CommitSortStrategies.Reverse };
+        var filter = new CommitFilter { SortBy = CommitSortStrategies.Topological };
         return repo.Commits.QueryBy(filter).Take(numCommits);
     }
 

--- a/Squashy/Program.cs
+++ b/Squashy/Program.cs
@@ -28,7 +28,7 @@ class Program
 
         Command squashCommitsCmd = new(
             "squash",
-            "Squash all commits between the specified start and end commits (inclusive)."
+            "Squash all commits between the specified first and second commits (inclusive)."
         );
         var firstCommitArg = new Argument<string>("firstCommit")
         {
@@ -38,6 +38,10 @@ class Program
         {
             Description = "The SHA of the second (newer) commit."
         };
+        var messageArg = new Argument<string>("message")
+        {
+            Description = "Message for the squashed commit."
+        };
         Option<bool> dryRunOption = new("--dry-run", "-x")
         {
             Description = "To show expected output.",
@@ -45,6 +49,7 @@ class Program
         };
         squashCommitsCmd.Add(firstCommitArg);
         squashCommitsCmd.Add(secondCommitArg);
+        squashCommitsCmd.Add(messageArg);
         squashCommitsCmd.Add(dryRunOption);
         squashCommitsCmd.SetAction(parseResult =>
         {
@@ -52,7 +57,9 @@ class Program
             git.Squash(
                 parseResult.GetValue(firstCommitArg),
                 parseResult.GetValue(secondCommitArg),
-                parseResult.GetValue(dryRunOption));
+                parseResult.GetValue(dryRunOption),
+                parseResult.GetValue(messageArg)
+            );
             return 0;
         });
 


### PR DESCRIPTION
### Description
Added support for `./Squashy -d <dir> squash <firstCommit> <secondCommit> <commitMessage>  -x`
* this shows expected output of the squash.
  * All commits after secondCommit
  * Squashed commit
  * All commits before firstCommit
* figures out if secondCommit comes before firstCommit and swaps them

### Testing
Tested following scenarios manually
* input commits in incorrect order
* secondCommit is the HEAD
* squash all commits
* squash commits in the middle