### PR TITLE
Implement Squash logic

### DIFF
--- a/Squashy.Tests/E2eTests.cs
+++ b/Squashy.Tests/E2eTests.cs
@@ -6,6 +6,7 @@ namespace Squashy.Tests;
 public class E2eTests
 {
     private string testRepoPath = Path.Combine(Environment.CurrentDirectory, ".test-repo");
+    private string squashMessage = "squashed commit";
     
     [SetUp]
     public void Setup()
@@ -13,7 +14,7 @@ public class E2eTests
     }
 
     [Test]
-    public void Git_Log_Output()
+    public void Test_Log_Output()
     {
         GitCommands git = CommonTestSetup();
         
@@ -46,11 +47,93 @@ public class E2eTests
         };
 
         Assert.That(commitLines.Length, Is.EqualTo(expectedMessages.Length), "Unexpected number of commit lines.");
-
         for (int i = 0; i < expectedMessages.Length; i++)
         {
             StringAssert.Contains(expectedMessages[i], commitLines[i], $"Message mismatch at line {i + 3}");
         }        
+    }
+    
+    // Test squashing head to middle
+    [Test]
+    public void Test_SquashWithHead()
+    {
+        GitCommands git = CommonTestSetup();
+
+        var originalShas = Utility.GetAllCommitHashes(testRepoPath);
+        // We'll squash commits between last (HEAD) and eight commits
+        string firstCommitSha = originalShas[0];
+        string secondCommitSha = originalShas[7];
+
+        git.Squash(firstCommitSha, secondCommitSha, false, squashMessage);
+
+        // We only expect 'create file 1' and 'squashed commit' messages to be
+        // present in the log
+        var newCommitMessages = Utility.GetAllCommitMessages(testRepoPath);
+        Assert.That(newCommitMessages.Count, Is.EqualTo(2), "Unexpected number of commit lines.");
+        Assert.That(newCommitMessages[0], Is.EqualTo("squashed commit"), "First commit is not 'squashed commit'");
+        Assert.That(newCommitMessages[1], Is.EqualTo("create file 1"), "Second commit is not 'create file 1");
+    }
+    
+    // Test squashing entire commit history
+    [Test]
+    public void Test_SquashWithHeadAndRoot()
+    {
+        GitCommands git = CommonTestSetup();
+
+        var originalShas = Utility.GetAllCommitHashes(testRepoPath);
+        // We'll squash commits between last (HEAD) and oldest commit
+        string firstCommitSha = originalShas[0];
+        string secondCommitSha = originalShas[8];
+
+        git.Squash(firstCommitSha, secondCommitSha, false, squashMessage);
+
+        // We only expect 'squashed commit' messages to be in the log
+        var newCommitMessages = Utility.GetAllCommitMessages(testRepoPath);
+        Assert.That(newCommitMessages.Count, Is.EqualTo(1), "Unexpected number of commit lines.");
+        Assert.That(newCommitMessages[0], Is.EqualTo("squashed commit"), "First commit is not 'squashed commit'");
+    }
+    
+    // Test squashing middle commit to root
+    [Test]
+    public void Test_SquashWithRoot()
+    {
+        GitCommands git = CommonTestSetup();
+
+        var originalShas = Utility.GetAllCommitHashes(testRepoPath);
+        // We'll squash commits between last (HEAD) and eight commits
+        string firstCommitSha = originalShas[1];
+        string secondCommitSha = originalShas[8];
+        git.Squash(firstCommitSha, secondCommitSha, false, squashMessage);
+
+        // We only expect 'delete file 3' and 'squashed commit' messages to be
+        // present in the log
+        var newCommitMessages = Utility.GetAllCommitMessages(testRepoPath);
+        Assert.That(newCommitMessages.Count, Is.EqualTo(2), "Unexpected number of commit lines.");
+        Assert.That(newCommitMessages[0], Is.EqualTo("delete file 3"), "Frist commit is not 'delete file 3");
+        Assert.That(newCommitMessages[1], Is.EqualTo("squashed commit"), "Second commit is not 'squashed commit'");
+    }
+    
+    // Test squashing block of commit between head and root
+    [Test]
+    public void TestSquash()
+    {
+        GitCommands git = CommonTestSetup();
+
+        var originalShas = Utility.GetAllCommitHashes(testRepoPath);
+        // We'll squash commits between last (HEAD) and eight commits
+        string firstCommitSha = originalShas[1];
+        string secondCommitSha = originalShas[7];
+
+        git.Squash(firstCommitSha, secondCommitSha, false, squashMessage);
+
+        // We only expect 'delete file 3', 'create file 1' and 'squashed commit' messages to be
+        // present in the log
+        var newCommitMessages = Utility.GetAllCommitMessages(testRepoPath);
+        Assert.That(newCommitMessages.Count, Is.EqualTo(3), "Unexpected number of commit lines.");
+        Assert.That(newCommitMessages[0], Is.EqualTo("delete file 3"), "First commit is not 'delete file 3");
+        Assert.That(newCommitMessages[1], Is.EqualTo("squashed commit"), "Second commit is not 'squashed commit'");
+        Assert.That(newCommitMessages[2], Is.EqualTo("create file 1"), "Third commit is not 'create file 1");
+
     }
 
     public GitCommands CommonTestSetup()

--- a/Squashy.Tests/E2eTests.cs
+++ b/Squashy.Tests/E2eTests.cs
@@ -1,0 +1,27 @@
+using NUnit.Framework;
+using Squashy;
+
+namespace Squashy.Tests;
+
+public class E2eTests
+{
+    private string testRepoPath = Path.Combine(Environment.CurrentDirectory, ".test-repo");
+    
+    [SetUp]
+    public void Setup()
+    { 
+    }
+
+    [Test]
+    public void DummyTest()
+    {
+        GitCommands git = CommonTestSetup();
+    }
+
+    public GitCommands CommonTestSetup()
+    {
+        Utility.CreateTestRepo(testRepoPath);
+        Utility.CreateFileCommits(testRepoPath);
+        return new GitCommands(testRepoPath);
+    }
+}

--- a/Squashy.Tests/E2eTests.cs
+++ b/Squashy.Tests/E2eTests.cs
@@ -13,9 +13,44 @@ public class E2eTests
     }
 
     [Test]
-    public void DummyTest()
+    public void Git_Log_Output()
     {
         GitCommands git = CommonTestSetup();
+        
+        // capture console output in a string
+        var sw = new StringWriter();
+        Console.SetOut(sw);
+
+        git.Log(10);
+
+        var consoleOutput = sw.ToString();
+
+        // reset console back to Stdout
+        Console.SetOut(new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true });
+        
+        // Split output lines and skip header
+        var lines = consoleOutput.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        var commitLines = lines.Skip(2).ToArray();
+
+        var expectedMessages = new[]
+        {
+            "delete file 3",
+            "delete file 2",
+            "delete file 1",
+            "modify file 3",
+            "modify file 2",
+            "modify file 1",
+            "create file 3",
+            "create file 2",
+            "create file 1"
+        };
+
+        Assert.That(commitLines.Length, Is.EqualTo(expectedMessages.Length), "Unexpected number of commit lines.");
+
+        for (int i = 0; i < expectedMessages.Length; i++)
+        {
+            StringAssert.Contains(expectedMessages[i], commitLines[i], $"Message mismatch at line {i + 3}");
+        }        
     }
 
     public GitCommands CommonTestSetup()

--- a/Squashy.Tests/GlobalUsings.cs
+++ b/Squashy.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/Squashy.Tests/Squashy.Tests.csproj
+++ b/Squashy.Tests/Squashy.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Squashy\Squashy.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Squashy.Tests/Utility.cs
+++ b/Squashy.Tests/Utility.cs
@@ -1,0 +1,53 @@
+using LibGit2Sharp; 
+using System.IO;
+
+namespace Squashy.Tests;
+
+static class Utility
+{
+    public static void CreateTestRepo(string testRepoPath) {
+        Console.WriteLine($"Setting up test repo '{testRepoPath}'"); 
+        // Delete repo if it already exists
+        if (Directory.Exists(testRepoPath))
+        {
+            Directory.Delete(testRepoPath, recursive: true);
+        }
+        Directory.CreateDirectory(testRepoPath);
+        Repository.Init(testRepoPath);
+    }
+
+    public static void CreateFileCommits(string testRepoPath, int numOfFiles = 3) {
+        Repository repo = new Repository(testRepoPath);
+        repo.Refs.UpdateTarget("HEAD", "refs/heads/main");
+
+        // Add files
+        for (int i = 1; i <= numOfFiles; i++) {
+            string filePath = Path.Combine(testRepoPath, $"file{i}.txt");
+            File.WriteAllText(filePath, $"file{i} content");
+
+            var sig = new Signature($"Test user {i}", $"testuser{i}@test.com", DateTimeOffset.Now);
+            Commands.Stage(repo, filePath);
+            repo.Commit($"create file {i}", sig, sig);
+        }
+
+        // Modify files
+        for (int i = 1; i <= numOfFiles; i++) {
+            string filePath = Path.Combine(testRepoPath, $"file{i}.txt");
+            File.AppendAllText(filePath, " modified..");
+            
+            var sig = new Signature($"Test user {i}", $"testuser{i}@test.com", DateTimeOffset.Now);
+            Commands.Stage(repo, filePath);
+            repo.Commit($"modify file {i}", sig, sig);
+        }
+
+        // Delete files
+        for (int i = 1; i <= numOfFiles; i++) {
+            string filePath = Path.Combine(testRepoPath, $"file{i}.txt");
+            File.Delete(filePath);
+            
+            var sig = new Signature($"Test user {i}", $"testuser{i}@test.com", DateTimeOffset.Now);
+            Commands.Stage(repo, filePath);
+            repo.Commit($"delete file {i}", sig, sig);
+        }
+    }
+}

--- a/Squashy.Tests/Utility.cs
+++ b/Squashy.Tests/Utility.cs
@@ -1,4 +1,5 @@
 using LibGit2Sharp; 
+using NUnit.Framework;
 using System.IO;
 
 namespace Squashy.Tests;
@@ -49,5 +50,19 @@ static class Utility
             Commands.Stage(repo, filePath);
             repo.Commit($"delete file {i}", sig, sig);
         }
+    }
+
+    public static List<string> GetAllCommitHashes(string testRepoPath)
+    {
+        Repository repo = new Repository(testRepoPath);
+        var filter = new CommitFilter { SortBy = CommitSortStrategies.Topological };
+        return repo.Commits.QueryBy(filter).Select(c => c.Id.Sha.Substring(0, 7)).ToList();
+    }
+
+    public static List<string> GetAllCommitMessages(string testRepoPath)
+    {
+        Repository repo = new Repository(testRepoPath);
+        var filter = new CommitFilter { SortBy = CommitSortStrategies.Topological };
+        return repo.Commits.QueryBy(filter).Select(c => c.MessageShort).ToList();
     }
 }

--- a/Squashy/GitCommands.cs
+++ b/Squashy/GitCommands.cs
@@ -271,6 +271,7 @@ public class GitCommands
                 ExcludeReachableFrom = commit,
                 SortBy = CommitSortStrategies.Topological
             }
-        ).SkipWhile(commit => commit.Sha == commit.Sha);
+        ).SkipWhile(c => c.Sha == commit.Sha);
     } 
 }
+

--- a/squashy.sln
+++ b/squashy.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Squashy", "Squashy\Squashy.csproj", "{48DC1B6B-0BAB-4939-845F-9E553A978292}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Squashy.Tests", "Squashy.Tests\Squashy.Tests.csproj", "{BE448C36-0A12-4523-85D8-1EDF55DE8E39}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{48DC1B6B-0BAB-4939-845F-9E553A978292}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{48DC1B6B-0BAB-4939-845F-9E553A978292}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{48DC1B6B-0BAB-4939-845F-9E553A978292}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE448C36-0A12-4523-85D8-1EDF55DE8E39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE448C36-0A12-4523-85D8-1EDF55DE8E39}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE448C36-0A12-4523-85D8-1EDF55DE8E39}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE448C36-0A12-4523-85D8-1EDF55DE8E39}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Add core squash logic.
Added support for `./Squashy -d <dir> squash <firstCommit> <secondCommit> <commitMessage>`

#### Testing
- Tested following scenarios manually as well as added automated tests
 - input commits in incorrect order
 - secondCommit is the HEAD
 - squash all commits
 - squash commits in the middle

Also added a test to validate `./Squashy log` output
